### PR TITLE
add (optional) max_split to stringx.split parameters

### DIFF
--- a/stringx.lua
+++ b/stringx.lua
@@ -20,8 +20,8 @@ function stringx.split(self, delim, max_split)
 	assert:type(max_split, "number", "stringx.split - max_split", 1)
 
 	if max_split then
-        assert(max_split > 0, "max_split must be positive!")
-    end
+		assert(max_split > 0, "max_split must be positive!")
+	end
 	
 	--we try to create as little garbage as possible!
 	--only one table to contain the result, plus the split strings.

--- a/stringx.lua
+++ b/stringx.lua
@@ -11,10 +11,13 @@ local stringx = setmetatable({}, {
 })
 
 --split a string on a delimiter into an ordered table
-function stringx.split(self, delim)
+function stringx.split(self, delim, max_split)
 	delim = delim or ""
+	max_split = max_split ~= nil and max_split or math.huge
+
 	assert:type(self, "string", "stringx.split - self", 1)
 	assert:type(delim, "string", "stringx.split - delim", 1)
+	assert:type(max_split, "number", "stringx.split - max_split", 1)
 
 	--we try to create as little garbage as possible!
 	--only one table to contain the result, plus the split strings.
@@ -46,7 +49,11 @@ function stringx.split(self, delim)
 				end
 			end
 			if has_whole_delim then
-				table.insert(res, i)
+				if #res < max_split then
+					table.insert(res, i)
+				else
+					break
+				end
 			end
 			--iterate forward
 			i = i + delim_length

--- a/stringx.lua
+++ b/stringx.lua
@@ -19,6 +19,10 @@ function stringx.split(self, delim, max_split)
 	assert:type(delim, "string", "stringx.split - delim", 1)
 	assert:type(max_split, "number", "stringx.split - max_split", 1)
 
+	if max_split then
+        assert(max_split > 0, "max_split must be positive!")
+    end
+	
 	--we try to create as little garbage as possible!
 	--only one table to contain the result, plus the split strings.
 	--so we do two passes, and  work with the bytes underlying the string


### PR DESCRIPTION
## Brief
This pull request introduces an optional amount of times to split the string.

## Description
The user may optionally provide a numerical value to tell the function to split up to `max_split` times. If the max is reached, it will then break from the loop and collect the sub-strings as normal. If none is provided, it will behave the same as normal, since `math.huge` would never *actually* be reached.

## Other Considerations
`math.huge` may not be optimal. I could change it to -1 and instead both check it's not negative one (and thus also less than said value). However, `math.huge` kinda *just works* here. If there's concern over using it, I'm definitely open to alternatives.

## Tests
```lua
require("batteries"):export()
local test_value = "zxnzxzxn/gottagofast/weeee/"

-- no max_split
local res = stringx.split(test, "/")
print(#res, unpack(res))
-- 4   zxnzxzxn        gottagofast     weeee    (empty string)

-- max_split one time
local res = stringx.split(test, "/", 1)
print(#res, unpack(res))
-- 2   zxnzxzxn        gottagofast/weeee/

-- max_split attempt of a big value
-- again, this works because the initial logic to terminate at string end is reached
res = stringx.split(test, "/", 6000)
print(#res, unpack(res))
-- 4   zxnzxzxn        gottagofast     weeee    (empty string)
```